### PR TITLE
Add open window picker for Quick Application Switching

### DIFF
--- a/Overview/Settings/SettingsView.swift
+++ b/Overview/Settings/SettingsView.swift
@@ -57,7 +57,7 @@ struct SettingsView: View {
                 .tabItem { Label("Layouts", systemImage: "rectangle.3.offgrid.fill") }
                 .frame(minHeight: 288, maxHeight: 504)
 
-            ShortcutSettingsTab(shortcutManager: shortcutManager)
+            ShortcutSettingsTab(shortcutManager: shortcutManager, sourceManager: sourceManager)
                 .tabItem { Label("Shortcuts", systemImage: "command.square.fill") }
                 .frame(minHeight: 288, maxHeight: 504)
 


### PR DESCRIPTION
## Summary
- pass `SourceManager` into `ShortcutSettingsTab`
- add menu of open windows when creating shortcuts
- update helper code to load windows and insert titles

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68710bbad8f88323b2df8a4a399178ff