### PR TITLE
Fix dropdown click issue on macOS 26 Beta 3

### DIFF
--- a/Overview/Window/WindowInteraction.swift
+++ b/Overview/Window/WindowInteraction.swift
@@ -104,6 +104,16 @@ private final class WindowInteractionHandler: NSView, NSMenuDelegate {
         stopCaptureItem.isEnabled = !isSelectionVisible
     }
 
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        // Allow underlying SwiftUI views to receive events when the selection
+        // interface is visible. Beta 3 changed event propagation behavior so
+        // simply calling `super.mouseDown` no longer forwarded clicks through
+        // this overlay. Returning nil when the selection view is active lets
+        // dropdowns and buttons remain interactive.
+        if isSelectionVisible { return nil }
+        return super.hitTest(point)
+    }
+
     override func mouseDown(with event: NSEvent) {
         if !editModeEnabled && !isSelectionVisible {
             onSourceWindowFocus?()


### PR DESCRIPTION
## Summary
- adjust `WindowInteractionHandler` so dropdowns work again

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6871368d9ec48323ada45476b130aa24