### PR TITLE
Implement window cycling shortcut

### DIFF
--- a/Overview/OverviewApp.swift
+++ b/Overview/OverviewApp.swift
@@ -209,6 +209,13 @@ struct OverviewApp: App {
                 }
                 .keyboardShortcut("e", modifiers: .command)
             }
+
+            CommandMenu("Window") {
+                Button("Cycle Windows") {
+                    appDelegate.windowManager.cyclePreviewWindows()
+                }
+                .keyboardShortcut(.tab, modifiers: .option)
+            }
         }
     }
 

--- a/Overview/Window/WindowManager.swift
+++ b/Overview/Window/WindowManager.swift
@@ -182,6 +182,29 @@ final class WindowManager: ObservableObject {
             logger.info("Successfully restored \(restoredCount) windows")
         }
     }
+
+    func cyclePreviewWindows() {
+        let windows = NSApp.orderedWindows.filter { activeWindows.contains($0) }
+
+        guard !windows.isEmpty else {
+            logger.debug("No active preview windows for cycling")
+            return
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        guard let keyWindow = NSApp.keyWindow,
+            let currentIndex = windows.firstIndex(of: keyWindow)
+        else {
+            windows.first?.makeKeyAndOrderFront(self)
+            logger.info("Preview window cycle started")
+            return
+        }
+
+        let nextIndex = (currentIndex + 1) % windows.count
+        windows[nextIndex].makeKeyAndOrderFront(self)
+        logger.info("Cycled to preview window \(nextIndex + 1)")
+    }
 }
 
 // MARK: - Window Delegate

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For development updates, please join our Discord:
 -   `⌘N` Create new preview window
 -   `⌘E` Toggle edit mode
 -   `⌘,` Open settings
+-   `⌥⇥` Cycle preview windows
 
 ### Settings
 


### PR DESCRIPTION
## Summary
- support cycling through preview windows with a new method in `WindowManager`
- expose the cycle command in the menu bar with Option+Tab
- document new shortcut in README

## Testing
- `swift build` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872262921d08323be7513bd20a40cbf