### PR TITLE
Allow spaces in layout titles

### DIFF
--- a/Overview/Layout/Settings/LayoutSettingsTab.swift
+++ b/Overview/Layout/Settings/LayoutSettingsTab.swift
@@ -127,9 +127,6 @@ struct LayoutSettingsTab: View {
                 HStack {
                     TextField("Layout name", text: $newLayoutName)
                         .textFieldStyle(.roundedBorder)
-                        .onChange(of: newLayoutName) { newValue in
-                            newLayoutName = newValue.trimmingCharacters(in: .whitespaces)
-                        }
 
                     Button("Create") {
                         createLayout()


### PR DESCRIPTION
## Summary
- update layout form to stop stripping whitespace from the input

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68722614e4c08323b04cfd14007acdba