### PR TITLE
Fix dropdown click issue on macOS 26 Beta 3

### DIFF
--- a/Overview/Window/WindowInteraction.swift
+++ b/Overview/Window/WindowInteraction.swift
@@ -104,6 +104,19 @@ private final class WindowInteractionHandler: NSView, NSMenuDelegate {
         stopCaptureItem.isEnabled = !isSelectionVisible
     }
 
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        // Allow selection view controls to receive clicks, but keep the
+        // context menu available via right-click or Control-click.
+        guard isSelectionVisible else { return super.hitTest(point) }
+
+        let event = window?.currentEvent ?? NSApp.currentEvent
+        let isContextClick =
+            event?.type == .rightMouseDown ||
+            (event?.type == .leftMouseDown && event?.modifierFlags.contains(.control) == true)
+
+        return isContextClick ? self : nil
+    }
+
     override func mouseDown(with event: NSEvent) {
         if !editModeEnabled && !isSelectionVisible {
             onSourceWindowFocus?()


### PR DESCRIPTION
## Summary
- adjust `WindowInteractionHandler` so dropdowns work again
- keep context menu accessible when the selection view is visible

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6871368d9ec48323ada45476b130aa24