### PR TITLE
Support saving window names in layouts

### DIFF
--- a/Overview/Layout/LayoutManager.swift
+++ b/Overview/Layout/LayoutManager.swift
@@ -30,13 +30,13 @@ final class LayoutManager: ObservableObject {
 
     // MARK: - Public Methods
 
-    func createLayout(name: String) -> Layout? {
+    func createLayout(name: String, windows: [Window]? = nil) -> Layout? {
         guard isLayoutNameUnique(name) else {
             logger.warning("Attempted to create layout with non-unique name: \(name)")
             return nil
         }
 
-        let currentWindows = windowServices.windowStorage.collectWindows()
+        let currentWindows = windows ?? windowServices.windowStorage.collectWindows()
         let layout = Layout(name: name, windows: currentWindows)
 
         layouts.append(layout)
@@ -45,7 +45,7 @@ final class LayoutManager: ObservableObject {
         return layout
     }
 
-    func updateLayout(id: UUID, name: String? = nil) {
+    func updateLayout(id: UUID, name: String? = nil, windows: [Window]? = nil) {
         guard let index = layouts.firstIndex(where: { $0.id == id }) else {
             logger.warning("Attempted to update non-existent layout: \(id)")
             return
@@ -59,7 +59,12 @@ final class LayoutManager: ObservableObject {
                 return
             }
             layout.update(name: name)
-        } else {
+        }
+
+        if let windows = windows {
+            layout.update(windows: windows)
+            logger.info("Updated layout '\(layout.name)' with \(windows.count) windows")
+        } else if name == nil {
             let currentWindows = windowServices.windowStorage.collectWindows()
             layout.update(windows: currentWindows)
             logger.info("Updated layout '\(layout.name)' with \(currentWindows.count) windows")

--- a/Overview/Layout/Settings/LayoutSettingsKeys.swift
+++ b/Overview/Layout/Settings/LayoutSettingsKeys.swift
@@ -12,4 +12,5 @@ extension Defaults.Keys {
     static let storedLayouts = Key<Data?>("storedLayouts", default: nil)
     static let launchLayoutUUID = Key<UUID?>("launchLayoutUUID", default: nil)
     static let closeWindowsOnApply = Key<Bool>("closeWindowsOnApply", default: true)
+    static let includeWindowNames = Key<Bool>("includeWindowNames", default: false)
 }

--- a/Overview/Layout/Settings/LayoutSettingsTab.swift
+++ b/Overview/Layout/Settings/LayoutSettingsTab.swift
@@ -37,6 +37,7 @@ struct LayoutSettingsTab: View {
 
     // Layout Settings
     @Default(.launchLayoutUUID) private var launchLayoutUUID
+    @Default(.includeWindowNames) private var includeWindowNames
 
     init(windowManager: WindowManager, layoutManager: LayoutManager) {
         self.layoutManager = layoutManager
@@ -151,6 +152,8 @@ struct LayoutSettingsTab: View {
 
                 Defaults.Toggle(
                     "Close all windows when applying layouts", key: .closeWindowsOnApply)
+                Defaults.Toggle(
+                    "Save window names with layout", key: .includeWindowNames)
             }
         }
         .formStyle(.grouped)
@@ -179,7 +182,7 @@ struct LayoutSettingsTab: View {
             Button("Cancel", role: .cancel) {}
             Button("Update") {
                 if let layout = layoutToModify {
-                    layoutManager.updateLayout(id: layout.id)
+                    windowManager.updateLayout(id: layout.id, includeWindowNames: includeWindowNames)
                 }
                 layoutToModify = nil
             }
@@ -271,7 +274,8 @@ struct LayoutSettingsTab: View {
         isJSONEditorVisible = true
     }
     private func createLayout() {
-        guard !newLayoutName.isEmpty, layoutManager.createLayout(name: newLayoutName) != nil
+        guard !newLayoutName.isEmpty,
+            windowManager.saveLayout(name: newLayoutName, includeWindowNames: includeWindowNames) != nil
         else {
             logger.warning("Attempted to create layout with empty or non-unique name")
             return
@@ -349,7 +353,7 @@ struct LayoutSettingsTab: View {
         }
 
         for layout in layoutsFromJSON {
-            _ = windowManager.saveLayout(name: layout.name)
+            _ = windowManager.saveLayout(name: layout.name, includeWindowNames: includeWindowNames)
 
             if let newLayout = layoutManager.layouts.last {
                 layoutManager.updateLayout(id: newLayout.id, name: layout.name)

--- a/Overview/Window/Services/WindowStorageService.swift
+++ b/Overview/Window/Services/WindowStorageService.swift
@@ -48,9 +48,9 @@ final class WindowStorageService {
         }
     }
 
-    func applyWindows(_ windows: [Window], using handler: (NSRect) -> Void) {
+    func applyWindows(_ windows: [Window], using handler: (Window) -> Void) {
         windows.forEach { window in
-            handler(window.frame)
+            handler(window)
         }
         logger.info("Successfully applied \(windows.count) windows")
     }

--- a/Overview/Window/Window.swift
+++ b/Overview/Window/Window.swift
@@ -12,15 +12,17 @@ struct Window: Codable, Equatable {
     let y: Double
     let width: Double
     let height: Double
+    let windowName: String?
 
     var frame: NSRect {
         NSRect(x: x, y: y, width: width, height: height)
     }
 
-    init(frame: NSRect) {
+    init(frame: NSRect, windowName: String? = nil) {
         self.x = frame.origin.x
         self.y = frame.origin.y
         self.width = frame.width
         self.height = frame.height
+        self.windowName = windowName
     }
 }


### PR DESCRIPTION
## Summary
- extend `LayoutManager` to optionally accept external window arrays
- add "includeWindowNames" defaults key
- expose a toggle in the layout settings tab
- track capture coordinators per window in `WindowManager`
- allow saving/updating layouts with window titles
- autoselect windows by name when applying a layout

## Testing
- `swiftc -o /tmp/app.out $(git ls-files '*.swift')` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687fd522b5ec8323ac8030b61de91819